### PR TITLE
fixed problem with CompoundObjects on rotation and translation

### DIFF
--- a/src/lib/object3d/Difference.js
+++ b/src/lib/object3d/Difference.js
@@ -4,15 +4,18 @@ import CompoundObject from './CompoundObject';
 import { ThreeBSP } from './threeCSG';
 
 export default class Difference extends CompoundObject {
-  getGeometry() {
+  getMesh() {
     // First element of array
-    let differenceMeshBSP = new ThreeBSP(this.children[0].getGeometry());
+    let differenceMeshBSP = new ThreeBSP(this.children[0].getMesh());
 
     // Difference with the rest
     for (let i = 1; i < this.children.length; i += 1) {
-      const bspMesh = new ThreeBSP(this.children[i].getGeometry());
+      const bspMesh = new ThreeBSP(this.children[i].getMesh());
       differenceMeshBSP = differenceMeshBSP.subtract(bspMesh);
     }
-    return differenceMeshBSP.toGeometry();
+
+    const mesh = differenceMeshBSP.toMesh(new Three.MeshLambertMaterial({color: 0xff0000}));
+    this.locateMesh(mesh);
+    return mesh;
   }
 }

--- a/src/lib/object3d/Intersection.js
+++ b/src/lib/object3d/Intersection.js
@@ -4,14 +4,17 @@ import CompoundObject from './CompoundObject';
 import { ThreeBSP } from './threeCSG';
 
 export default class Intersection extends CompoundObject {
-  getGeometry() {
+  getMesh() {
     // First element of array
     let intersectionMeshBSP = new ThreeBSP(this.children[0].getGeometry());
     // Intersect with the rest
     for (let i = 1; i < this.children.length; i += 1) {
-      const bspMesh = new ThreeBSP(this.children[i].getGeometry());
+      const bspMesh = new ThreeBSP(this.children[i].getMesh());
       intersectionMeshBSP = intersectionMeshBSP.intersect(bspMesh);
     }
-    return intersectionMeshBSP.toGeometry(new Three.MeshLambertMaterial({color: 0xff0000}));
+    const mesh = intersectionMeshBSP.toMesh(new Three.MeshLambertMaterial({color: 0xff0000}));
+
+    this.locateMesh(mesh);
+    return mesh;
   }
 }

--- a/src/lib/object3d/Object3D.js
+++ b/src/lib/object3d/Object3D.js
@@ -67,8 +67,7 @@ export default class Object3D {
     this.operations.push(operation);
   }
 
-  getMesh() {
-
+  locateMesh(mesh){
     if(this.operations){
       this.operations.forEach( operation => this.trMatrix.makeOperation(operation));
     }
@@ -76,24 +75,24 @@ export default class Object3D {
     const tr = this.trMatrix.globalTranslation;
     const rot = this.trMatrix.globalXYZAngles;
 
-    console.log("tr: " + tr.x +" "+ tr.y +" "+ tr.z);
-    console.log("rot: " + rot.x +" "+rot.y+" "+rot.z);
-
-
-    const geometry = this.getGeometry();
-    const material = new Three.MeshLambertMaterial({color: 0xff0000});
-    const mesh = new Three.Mesh(geometry, material);
-    
     mesh.position.x = tr.x;
     mesh.position.y = tr.y;
     mesh.position.z = tr.z;
     mesh.rotateOnWorldAxis(new Three.Vector3(1,0,0), rot.x);
     mesh.rotateOnWorldAxis(new Three.Vector3(0,1,0), rot.y);
     mesh.rotateOnWorldAxis(new Three.Vector3(0,0,1), rot.z);
+  }
+
+  getMesh() {
+
+    const geometry = this.getGeometry();
+    const material = new Three.MeshLambertMaterial({color: 0xff0000});
+    const mesh = new Three.Mesh(geometry, material);
 
     console.log('drawing mesh');
     // TODO Apply operations
-
+    this.locateMesh(mesh);
+    
     return mesh;
   }
 

--- a/src/lib/object3d/Union.js
+++ b/src/lib/object3d/Union.js
@@ -4,17 +4,19 @@ import CompoundObject from './CompoundObject';
 import { ThreeBSP } from './threeCSG';
 
 export default class Union extends CompoundObject {
-  getGeometry() {
+  getMesh() {
     // First element of array
-    let unionMeshBSP = new ThreeBSP(this.children[0].getGeometry());
+    let unionMeshBSP = new ThreeBSP(this.children[0].getMesh());
 
     // Union with the rest
     for (let i = 1; i < this.children.length; i += 1) {
-      const bspMesh = new ThreeBSP(this.children[i].getGeometry());
+      const bspMesh = new ThreeBSP(this.children[i].getMesh());
       unionMeshBSP = unionMeshBSP.union(bspMesh);
     }
 
     console.log('compute union');
-    return unionMeshBSP.toGeometry();
+    const mesh = unionMeshBSP.toMesh(new Three.MeshLambertMaterial({color: 0xff0000}));
+    this.locateMesh(mesh);
+    return mesh;
   }
 }


### PR DESCRIPTION
CompountObjects need to overload the getMesh method of Object3D.
The reason is that object is translated/located on that function. If Union/Difference/Intersection return only a geometry, the geometry is not located, and thus these operations do not work.